### PR TITLE
More updates

### DIFF
--- a/amp/scripts/apply.sh
+++ b/amp/scripts/apply.sh
@@ -7,10 +7,14 @@ STACK_NAME="${ACORN_EXTERNAL_ID}"
 ./scripts/stack_log.sh ${STACK_NAME} &
 . ./scripts/record_events.sh
 
+record_success() {
+    record_event "Service${ACORN_EVENT^}d" "CFN Stack: ${STACK_NAME} ${ACORN_EVENT}d successfully"
+}
+
 if [ "${ACORN_EVENT}" = "delete" ]; then
     aws cloudformation delete-stack --stack-name "${STACK_NAME}"
     aws cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}"
-    record_events "${ACORN_EVENT}d" "Successfully deleted stack ${STACK_NAME}"
+    record_success
     exit 0
 fi
 
@@ -31,7 +35,7 @@ cat cfn.yaml
 aws cloudformation deploy --template-file cfn.yaml --stack-name "${STACK_NAME}" --capabilities CAPABILITY_IAM --capabilities CAPABILITY_NAMED_IAM --no-fail-on-empty-changeset --no-cli-pager
 aws cloudformation describe-stacks --stack-name "${STACK_NAME}" --query 'Stacks[0].Outputs' > outputs.json
 
-record_events "${ACORN_EVENT}d" "Successfully applied stack ${STACK_NAME}"
+record_success
 
 # Render Output
 url=$(jq -r '.[] | select(.OutputKey=="AMPEndpointURL")|.OutputValue' outputs.json)

--- a/rds/aurora-cluster/Acornfile
+++ b/rds/aurora-cluster/Acornfile
@@ -59,6 +59,7 @@ jobs: apply: {
 			"cloudformation:ExecuteChangeSet",
 			"cloudformation:PreviewStackUpdate",
 			"cloudformation:UpdateStack",
+			"cloudformation:RollbackStack",
 			"cloudformation:GetTemplateSummary",
 			"cloudformation:DeleteStack",
 			"ssm:GetParameters",

--- a/rds/serverless/Acornfile
+++ b/rds/serverless/Acornfile
@@ -56,6 +56,7 @@ jobs: apply: {
 			"cloudformation:ExecuteChangeSet",
 			"cloudformation:PreviewStackUpdate",
 			"cloudformation:UpdateStack",
+			"cloudformation:RollbackStack",
 			"cloudformation:GetTemplateSummary",
 			"cloudformation:DeleteStack",
 			"ssm:GetParameters",

--- a/rds/serverlessv2/Acornfile
+++ b/rds/serverlessv2/Acornfile
@@ -59,6 +59,7 @@ jobs: apply: {
 				"cloudformation:ExecuteChangeSet",
 				"cloudformation:PreviewStackUpdate",
 				"cloudformation:UpdateStack",
+				"cloudformation:RollbackStack",
 				"cloudformation:GetTemplateSummary",
 				"cloudformation:DeleteStack",
 				"ssm:GetParameters",

--- a/s3/Acornfile
+++ b/s3/Acornfile
@@ -41,6 +41,7 @@ jobs: apply: {
 			"cloudformation:DescribeStacks",
 			"cloudformation:CreateChangeSet",
 			"cloudformation:DescribeStackEvents",
+			"cloudformation:DescribeStackResources",
 			"cloudformation:DescribeChangeSet",
 			"cloudformation:ExecuteChangeSet",
 			"cloudformation:PreviewStackUpdate",
@@ -58,12 +59,11 @@ jobs: apply: {
 			"s3:DeleteBucketPolicy",
 		]
 		resources: ["*"]
-	},
-		{
-			apiGroup: "api.acorn.io"
-			verbs: [
-				"create",
-			]
-			resources: ["events"]
-		}]
+	}, {
+		apiGroup: "api.acorn.io"
+		verbs: [
+			"create",
+		]
+		resources: ["events"]
+	}]
 }

--- a/s3/Dockerfile
+++ b/s3/Dockerfile
@@ -2,11 +2,14 @@ FROM cgr.dev/chainguard/go as build
 
 WORKDIR /src/s3
 COPY --from=common . ../libs/
+COPY --from=utils ./cfn-events ../cfn-events/
 COPY . .
 RUN --mount=type=cache,target=/root/go/pkg \
     --mount=type=cache,target=/root/.cache/go-build \
     ls ../ &&\
-    go build -o s3 
+    go build -o s3 . && \
+    cd ../cfn-events && \
+    go build -o cfn-events .
 
 FROM cgr.dev/chainguard/wolfi-base
 RUN apk add -U --no-cache nodejs bash busybox aws-cli jq curl zip && \
@@ -20,4 +23,5 @@ COPY ./cdk.json ./
 COPY ./scripts ./scripts
 COPY --from=utils ./scripts/ ./scripts/
 COPY --from=build /src/s3/s3 .
+COPY --from=build /src/cfn-events/cfn-events .
 CMD [ "/app/scripts/apply.sh" ]

--- a/sqs/Acornfile
+++ b/sqs/Acornfile
@@ -50,6 +50,7 @@ jobs: apply: {
 			"cloudformation:DescribeStacks",
 			"cloudformation:CreateChangeSet",
 			"cloudformation:DescribeStackEvents",
+			"cloudformation:DescribeStackResources",
 			"cloudformation:DescribeChangeSet",
 			"cloudformation:ExecuteChangeSet",
 			"cloudformation:PreviewStackUpdate",
@@ -59,6 +60,12 @@ jobs: apply: {
 			"sqs:*",
 		]
 		resources: ["*"]
+	}, {
+		apiGroup: "api.acorn.io"
+		verbs: [
+			"create",
+		]
+		resources: ["events"]
 	}]
 }
 

--- a/sqs/Dockerfile
+++ b/sqs/Dockerfile
@@ -2,11 +2,14 @@ FROM cgr.dev/chainguard/go as build
 
 WORKDIR /src/sqs
 COPY --from=common . ../libs/
+COPY --from=utils ./cfn-events/ ../cfn-events/
 COPY . .
 RUN --mount=type=cache,target=/root/go/pkg \
     --mount=type=cache,target=/root/.cache/go-build \
     ls ../ &&\
-    go build -o sqs
+    go build -o sqs && \
+    cd ../cfn-events && \
+    go build -o cfn-events .
 
 FROM cgr.dev/chainguard/wolfi-base
 RUN apk add -U --no-cache nodejs bash busybox aws-cli jq curl zip && \
@@ -20,4 +23,5 @@ COPY ./cdk.json ./
 COPY ./scripts ./scripts
 COPY --from=build /src/sqs/sqs .
 COPY --from=utils . ./scripts/ ./scripts/
+COPY --from=build /src/cfn-events/cfn-events .
 CMD [ "/app/scripts/apply.sh" ]

--- a/sqs/scripts/apply.sh
+++ b/sqs/scripts/apply.sh
@@ -3,11 +3,17 @@ set -e
 
 STACK_NAME="${ACORN_EXTERNAL_ID}"
 
-./scripts/stack_log.sh ${STACK_NAME} &
+./scripts/stacklog.sh ${STACK_NAME} &
+. ./scripts/record_event.sh
+
+record_success() {
+    record_event "Service${ACORN_EVENT^}d" "CFN Stack: ${STACK_NAME} ${ACORN_EVENT}d successfully"
+}
 
 if [ "${ACORN_EVENT}" = "delete" ]; then
     aws cloudformation delete-stack --stack-name "${STACK_NAME}"
     aws cloudformation wait stack-delete-complete --stack-name "${STACK_NAME}"
+    record_success
     exit 0
 fi
 
@@ -37,6 +43,7 @@ proto="${url%%://*}"
 no_proto="${url#*://}"
 address="${no_proto%%/*}"
 uri="${no_proto#*$address}"
+record_success
 
 
 cat > /run/secrets/output <<EOF

--- a/utils/scripts/record_event.sh
+++ b/utils/scripts/record_event.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
+set +x
+
 function record_event() {
+	set +x
 	# Consume expected environment variables and files
 	local sa="/var/run/secrets/kubernetes.io/serviceaccount"
 	local token=$(cat "${sa}/token")


### PR DESCRIPTION
RDS: Stopped running apply_and_render on delete.
RDS: Add ability to attempt stuck Rollback
cfn-events: refactored to have better language when deleting.
SQS: Add events and cfn-events.
S3: Add standard events along with cfn-events.
AMP: Made event language similar to everything else and added cfn-events