### PR TITLE
Update provides updates to RDS

### DIFF
--- a/rds/aurora-cluster/Acornfile
+++ b/rds/aurora-cluster/Acornfile
@@ -8,10 +8,21 @@ args: {
 	dbName: "instance"
 	// Deletion protection, you must set to false in order for the RDS db to be deleted. Default is false.
 	deletionProtection: false
-	// The instance class to use.(medium or large) Default is "small". Not all instances are available in all regions.
-	instanceSize: *"medium" | "large"
+	// The instance class for the database server to use. Default is "burstable".
+	// - burstable (good for dev/test and light workloads.)
+	// - burstableGraviton (good for dev/test and light workloads.)
+	// - memoryOptimized (good for memory intensive workloads.)
+	// **Updating this setting will cause downtime on the RDS instance.**
+	instanceClass: "burstable"
+	// The instance size to use.(medium, large, xlarge, or 2xlarge) Default is "medium". Not all instance sizes are available in all regions.
+	// **Updating this setting will cause downtime on the RDS instance.**
+	instanceSize: "medium"
 	// RDS MySQL Database Parameters to apply to the cluster. Must be k/v string pairs(ex. max_connections: "1000").
 	parameters: {}
+	// Do not take a final snapshot on delete or update and replace operations. Default is false. If skip is enabled the DB will be gone forever if deleted or replaced.
+	skipSnapshotOnDelete: false
+	// Enable Performance insights. Default is false.
+	enablePerformanceInsights: false
 	// Key value pairs of tags to apply to the RDS cluster and all other resources.
 	tags: {}
 }
@@ -56,10 +67,12 @@ jobs: apply: {
 			"cloudformation:DescribeStackEvents",
 			"cloudformation:DescribeStackResources",
 			"cloudformation:DescribeChangeSet",
+			"cloudformation:ListChangeSets",
 			"cloudformation:ExecuteChangeSet",
 			"cloudformation:PreviewStackUpdate",
 			"cloudformation:UpdateStack",
 			"cloudformation:RollbackStack",
+			"cloudformation:GetTemplate",
 			"cloudformation:GetTemplateSummary",
 			"cloudformation:DeleteStack",
 			"ssm:GetParameters",

--- a/rds/scripts/apply.sh
+++ b/rds/scripts/apply.sh
@@ -19,6 +19,31 @@ event_success() {
   record_event "Service${ACORN_EVENT^}d" "CFN Stack: ${STACK_NAME} ${ACORN_EVENT}d successfully"
 }
 
+get_current_applied_template() {
+  aws cloudformation get-template --stack-name "${STACK_NAME}" --query 'TemplateBody' --output json | jq -r . > current_applied_template.yaml
+  python -c 'import yaml, json, sys; print(json.dumps(yaml.safe_load(sys.stdin)))' < current_applied_template.yaml | jq -r . > current-cfn.json
+  python -c 'import yaml, json, sys; print(json.dumps(yaml.safe_load(sys.stdin)))' < cfn.yaml | jq -r . > cfn.json
+}
+
+## This is a workaround because retention policy updates are treated as no-op by CFN. Look forward to deleting this.
+update_stack_for_deletion_policy_only_updates() {
+  if [ "$(aws cloudformation list-change-sets --stack-name ${STACK_NAME} | jq '.Summaries[] | "\(.CreationTime):\(.Status):\(.StatusReason)"'|sort -r | head -n 1 |grep "didn't contain changes" |wc -l)" != "1" ]; then
+    echo "Was not an empty change set... exiting"
+    exit 0
+  fi
+  get_current_applied_template
+
+  current_deletion_policy=$(jq -r '.Resources | to_entries[] | select(.key | startswith("Cluster") and (. | startswith("ClusterSecretAttachment")| not) and (. | startswith("ClusterInstance") | not)) | .value.DeletionPolicy' current-cfn.json)
+  new_deletion_policy=$(jq -r '.Resources | to_entries[] | select(.key | startswith("Cluster") and (. | startswith("ClusterSecretAttachment")| not) and (. | startswith("ClusterInstance") | not)) | .value.DeletionPolicy' cfn.json)
+
+  if [ "${current_deletion_policy}" != "${new_deletion_policy}" ]; then
+    echo "DeletionPolicy changed, updating stack..."
+    aws cloudformation update-stack --stack-name "${STACK_NAME}" --template-body file://cfn.yaml --capabilities CAPABILITY_IAM --capabilities CAPABILITY_NAMED_IAM --no-cli-pager
+    aws cloudformation wait stack-update-complete --stack-name "${STACK_NAME}" --no-cli-pager
+    event_success
+  fi
+}
+
 apply_and_render() {
   # Run CDK synth
   cdk_synth
@@ -66,9 +91,18 @@ set -x
 }
 
 delete_stack() {
+    cdk_synth
     if $(grep 'DeletionProtection: true' cfn.yaml > /dev/null 2>&1); then
         echo "DeletionProtection is enabled, update acorn app with '--deletion-protection=false' to delete this stack..."
         exit 1
+    fi
+    get_current_applied_template
+    current_deletion_protection=$(jq -r '.Resources | to_entries[] | select(.key | startswith("Cluster") and (. | startswith("ClusterSecretAttachment")| not) and (. | startswith("ClusterInstance") | not)) | .value.Properties.DeletionProtection' current-cfn.json)
+
+    # If current protection is true, and we are trying to set to false, run update
+    if [ "${current_deletion_protection}" = "true" ]; then
+      echo "Need to update stack to disable deletion protection..."
+      aws cloudformation deploy --template-file cfn.yaml --stack-name "${STACK_NAME}" --capabilities CAPABILITY_IAM --capabilities CAPABILITY_NAMED_IAM --no-fail-on-empty-changeset --no-cli-pager
     fi
 
     # Run CloudFormation
@@ -94,4 +128,7 @@ fi
 
 # Run CloudFormation
 apply_and_render
+if [ "${ACORN_EVENT}" = "update" ]; then
+  update_stack_for_deletion_policy_only_updates
+fi
 exit 0

--- a/rds/serverless/Acornfile
+++ b/rds/serverless/Acornfile
@@ -10,6 +10,14 @@ args: {
 	deletionProtection: false
 	// RDS MySQL Database Parameters to apply to the cluster. Must be k/v string pairs(ex. max_connections: "1000").
 	parameters: {}
+	// Aurora Capacity Units minimum value must be 1, 2, 4, 8, 16, 32, 64, 128, 256, 384. Default is 4.
+	auroraCapacityUnitsMin: 4
+	// Aurora Capacity Units maximum value must be 1, 2, 4, 8, 16, 32, 64, 128, 256, 384. Default is 8.
+	auroraCapacityUnitsMax: 8
+	// Time in minutes to pause Aurora serverless DB cluster after it's been idle. Default is 10 set to 0 to disable.
+	AuroraPauseDurationMinutes: 10
+	// Do not take a final snapshot on delete or update and replace operations. Default is false. If skip is enabled the DB will be gone forever if deleted or replaced.
+	skipSnapshotOnDelete: false
 	// Key value pairs of tags to apply to the RDS cluster and all other resources.
 	tags: {}
 }
@@ -53,10 +61,12 @@ jobs: apply: {
 			"cloudformation:DescribeStackEvents",
 			"cloudformation:DescribeStackResources",
 			"cloudformation:DescribeChangeSet",
+			"cloudformation:ListChangeSets",
 			"cloudformation:ExecuteChangeSet",
 			"cloudformation:PreviewStackUpdate",
 			"cloudformation:UpdateStack",
 			"cloudformation:RollbackStack",
+			"cloudformation:GetTemplate",
 			"cloudformation:GetTemplateSummary",
 			"cloudformation:DeleteStack",
 			"ssm:GetParameters",

--- a/rds/serverless/rds.go
+++ b/rds/serverless/rds.go
@@ -44,11 +44,14 @@ func NewRDSStack(scope constructs.Construct, props *rds.RDSStackProps) awscdk.St
 		DefaultDatabaseName: jsii.String(props.DatabaseName),
 		CopyTagsToSnapshot:  jsii.Bool(true),
 		DeletionProtection:  jsii.Bool(props.DeletionProtection),
-		RemovalPolicy:       awscdk.RemovalPolicy_SNAPSHOT,
-		Credentials:         creds,
-		Vpc:                 vpc,
+		RemovalPolicy:       rds.GetRemovalPolicy(props),
+
+		Credentials: creds,
+		Vpc:         vpc,
 		Scaling: &awsrds.ServerlessScalingOptions{
-			AutoPause: awscdk.Duration_Minutes(jsii.Number(10)),
+			AutoPause:   awscdk.Duration_Minutes(jsii.Number(props.AutoPauseDurationMinutes)),
+			MinCapacity: getACUFromInt(props.AuroraCapacityUnitsMin),
+			MaxCapacity: getACUFromInt(props.AuroraCapacityUnitsMax),
 		},
 		SubnetGroup:    subnetGroup,
 		SecurityGroups: sgs,
@@ -75,6 +78,34 @@ func NewRDSStack(scope constructs.Construct, props *rds.RDSStackProps) awscdk.St
 	})
 
 	return stack
+}
+
+func getACUFromInt(i int) awsrds.AuroraCapacityUnit {
+	switch i {
+	case 1:
+		return awsrds.AuroraCapacityUnit_ACU_1
+	case 2:
+		return awsrds.AuroraCapacityUnit_ACU_2
+	case 4:
+		return awsrds.AuroraCapacityUnit_ACU_4
+	case 8:
+		return awsrds.AuroraCapacityUnit_ACU_8
+	case 16:
+		return awsrds.AuroraCapacityUnit_ACU_16
+	case 32:
+		return awsrds.AuroraCapacityUnit_ACU_32
+	case 64:
+		return awsrds.AuroraCapacityUnit_ACU_64
+	case 128:
+		return awsrds.AuroraCapacityUnit_ACU_128
+	case 256:
+		return awsrds.AuroraCapacityUnit_ACU_256
+	case 384:
+		return awsrds.AuroraCapacityUnit_ACU_384
+	default:
+		logrus.Fatalf("invalid ACU request must be 1, 2, 4, 8, 16, 32, 64, 128, 256, 384. Passed in: %d", i)
+	}
+	return ""
 }
 
 func main() {

--- a/rds/serverlessv2/Acornfile
+++ b/rds/serverlessv2/Acornfile
@@ -8,10 +8,18 @@ args: {
 	dbName: "instance"
 	// Deletion protection, you must set to false in order for the RDS db to be deleted. Default is false
 	deletionProtection: false
-	// Size of the instance. Default is small
+	// Size of the instance. Default is small. (Deprecated no longer has an effect)
 	instanceSize: "small"
+	// Aurora Capacity Units minimum value must be 1, 2, 4, 8, 16, 32, 64, 128, 256, 384. Default is .5.
+	auroraCapacityUnitsV2Min: 0.5
+	// Aurora Capacity Units maximum value must be 1, 2, 4, 8, 16, 32, 64, 128, 256, 384. Default is 8.
+	auroraCapacityUnitsV2Max: 8
 	// RDS MySQL Database Parameters to apply to the cluster. Must be k/v string pairs(ex. max_connections: "1000").
 	parameters: {}
+	// Do not take a final snapshot on delete or update and replace operations. Default is false. If skip is enabled the DB will be gone forever if deleted or replaced.
+	skipSnapshotOnDelete: false
+	// Enable Performance Insights. Default is false.
+	enablePerformanceInsights: false
 	// Key value pairs of tags to apply to the RDS cluster and all other resources.
 	tags: {}
 }
@@ -54,12 +62,14 @@ jobs: apply: {
 				"cloudformation:DescribeStacks",
 				"cloudformation:CreateChangeSet",
 				"cloudformation:DescribeChangeSet",
+				"cloudformation:ListChangeSets",
 				"cloudformation:DescribeStackEvents",
 				"cloudformation:DescribeStackResources",
 				"cloudformation:ExecuteChangeSet",
 				"cloudformation:PreviewStackUpdate",
 				"cloudformation:UpdateStack",
 				"cloudformation:RollbackStack",
+				"cloudformation:GetTemplate",
 				"cloudformation:GetTemplateSummary",
 				"cloudformation:DeleteStack",
 				"ssm:GetParameters",
@@ -91,7 +101,7 @@ if args.username != "" {
 			MYSQL_ADMIN_USER:     args.adminUsername
 			MYSQL_ADMIN_PASSWORD: "@{secrets.admin.password}"
 			MYSQL_USER:           args.username
-			MYSWL_PASSWORD:       "@{secrets.user.password}"
+			MYSQL_PASSWORD:       "@{secrets.user.password}"
 			MYSQL_HOST:           "@{service.rds.address}"
 			MYSQL_DATABASE:       args.dbName
 		}


### PR DESCRIPTION
Allows selecting instance class and sizes across all 3 dbs Serverlessv2 now uses Writer instance, no longer using deprecated API Aurora Cluster now users Writer instance, no longer using deprecated InstanceType