### PR TITLE
Added event watching to cdk-runner

### DIFF
--- a/utils/cdk-runner/pkg/aws/cloudformation/delete.go
+++ b/utils/cdk-runner/pkg/aws/cloudformation/delete.go
@@ -46,6 +46,15 @@ func Delete(c *Client, stackName string) error {
 		return err
 	}
 
+	stack, err := GetStack(c, stackName)
+	if err != nil && stack.Exists {
+		return err
+	} else if !stack.Exists {
+		// Return nil, since we wanted it deleted.
+		return nil
+	}
+	go stack.LogEvents(c)
+
 	return deleteStackWaiter.Wait(c.Ctx, &cloudformation.DescribeStacksInput{
 		StackName: aws.String(stackName),
 	}, time.Minute*60)

--- a/utils/cdk-runner/pkg/aws/cloudformation/deploy.go
+++ b/utils/cdk-runner/pkg/aws/cloudformation/deploy.go
@@ -41,6 +41,8 @@ func DeployStack(c *Client, stackName, template string) error {
 		return err
 	}
 
+	go stack.LogEvents(c)
+
 	// Before doing anything see if we are in a failed state that can be recovered.
 	if err := stack.AutoRecover(c); err != nil {
 		return err

--- a/utils/cdk-runner/pkg/aws/cloudformation/rollback.go
+++ b/utils/cdk-runner/pkg/aws/cloudformation/rollback.go
@@ -9,9 +9,11 @@ import (
 
 func Rollback(c *Client, stackName string) error {
 	rollbackWaiter := cloudformation.NewStackRollbackCompleteWaiter(c.Client)
-	c.Client.RollbackStack(c.Ctx, &cloudformation.RollbackStackInput{
+	if _, err := c.Client.RollbackStack(c.Ctx, &cloudformation.RollbackStackInput{
 		StackName: aws.String(stackName),
-	})
+	}); err != nil {
+		return err
+	}
 	if err := rollbackWaiter.Wait(c.Ctx, &cloudformation.DescribeStacksInput{
 		StackName: aws.String(stackName),
 	}, time.Minute*60); err != nil {


### PR DESCRIPTION
Stackevents are now output during job execution.
If during job execution a stack event fails, it is written to /dev/termination-log and captured by Acorn and added to the app and container statuses.