### PR TITLE
Fix couple bugs

### DIFF
--- a/utils/cdk-runner/main.go
+++ b/utils/cdk-runner/main.go
@@ -119,6 +119,7 @@ func main() {
 
 	if event == "delete" {
 		if err := deleteStack(stackName); err != nil {
+			os.WriteFile("/dev/termination-log", []byte(err.Error()), 0644)
 			logrus.Fatal(err)
 		}
 	}

--- a/utils/cdk-runner/pkg/aws/cloudformation/stack.go
+++ b/utils/cdk-runner/pkg/aws/cloudformation/stack.go
@@ -95,6 +95,12 @@ func StackOperationInProgress(c *Client, stackName string) (bool, string, error)
 	} else if err != nil {
 		return false, "", err
 	}
+
+	// We should be able to recover from this one.
+	if stack.Current.StackStatus == types.StackStatusReviewInProgress {
+		return false, string(stack.Current.StackStatus), nil
+	}
+
 	return strings.Contains(string(stack.Current.StackStatus), "IN_PROGRESS"), string(stack.Current.StackStatus), nil
 }
 


### PR DESCRIPTION
Fixes a bug when the Review In Progress state would prevent the service Acorn from ever running if it failed to create initially.

Now logs error to /dev/termination-log when delete protection is on.