### PR TITLE
fix actions filtering again

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,28 +3,11 @@ on:
   push:
     tags:
       - "**/v[0-9]*"
+      - "!utils/**/v[0-9]*"
 
 jobs:
-  changes:
-    name: Check paths
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    outputs:
-      utils: ${{ steps.filter.outputs.utils }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Filter
-        uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            utils:
-              - 'utils/**'
   publish:
-    needs: changes
-    if: ${{ needs.changes.outputs.utils == 'false' }}
+    name: Publish
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:
       - name: Checkout

--- a/.github/workflows/utils-image-release.yaml
+++ b/.github/workflows/utils-image-release.yaml
@@ -2,29 +2,10 @@ name: Publish Utility Images
 on:
   push:
     tags:
-      - "**/v[0-9]*"
+      - "utils/**/v[0-9]*"
 
 jobs:
-  changes:
-    name: Check paths
-    runs-on: buildjet-4vcpu-ubuntu-2204
-    outputs:
-      utils: ${{ steps.filter.outputs.utils }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Filter
-        uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            utils:
-              - 'utils/**'
   publish:
-    needs: changes
-    if: ${{ needs.changes.outputs.utils == 'true' }}
     name: Publish
     runs-on: buildjet-4vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
There was a flaw in my logic before. We should only run the utility image action if the tag contains utils/ and only run the service image action if it doesn't. I was filtering for the utils being part of the diff which isn't quite right.