### PR TITLE
add: sign images in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,4 +31,4 @@ jobs:
           acorn push --sign --key="${{ secrets.SIG_PRIVATE_KEY }}" ghcr.io/acorn-io/aws/${IMAGE}:${TAG}
         env:
           ACORN_IMAGE_SIGN_PASSWORD: ${{ secrets.SIG_PRIVATE_KEY_PASSWORD }}
-```     
+

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,4 +28,7 @@ jobs:
       - name: Build and Publish with signature
         run: |
           acorn build --platform linux/amd64 --platform linux/arm64 -t ghcr.io/acorn-io/aws/${IMAGE}:${TAG} ./${IMAGE}
-          acorn push --sign --key="${{ secrets.SIGNATURE_PRIVATE_KEY }}" ghcr.io/acorn-io/aws/${IMAGE}:${TAG}
+          acorn push --sign --key="${{ secrets.SIG_PRIVATE_KEY }}" ghcr.io/acorn-io/aws/${IMAGE}:${TAG}
+        env:
+          ACORN_IMAGE_SIGN_PASSWORD: ${{ secrets.SIG_PRIVATE_KEY_PASSWORD }}
+```     

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,12 +25,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set image and tag
         run: ./scripts/setup_tags.sh
-      - name: Build and Publish
+      - name: Build and Publish with signature
         run: |
-          acorn build --platform linux/amd64 --platform linux/arm64 --push -t ghcr.io/acorn-io/aws/${IMAGE}:${TAG} ./${IMAGE}
-      - name: Sign Image and Push Signature
-        uses: acorn-io/actions-sign@v1
-        with:
-          image: ghcr.io/acorn-io/aws/${IMAGE}:${TAG}
-          key: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          push: true
+          acorn build --platform linux/amd64 --platform linux/arm64 -t ghcr.io/acorn-io/aws/${IMAGE}:${TAG} ./${IMAGE}
+          acorn push --sign --key="${{ secrets.SIGNATURE_PRIVATE_KEY }}" ghcr.io/acorn-io/aws/${IMAGE}:${TAG}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,3 +28,9 @@ jobs:
       - name: Build and Publish
         run: |
           acorn build --platform linux/amd64 --platform linux/arm64 --push -t ghcr.io/acorn-io/aws/${IMAGE}:${TAG} ./${IMAGE}
+      - name: Sign Image and Push Signature
+        uses: acorn-io/actions-sign@v1
+        with:
+          image: ghcr.io/acorn-io/aws/${IMAGE}:${TAG}
+          key: ${{ secrets.COSIGN_PRIVATE_KEY }}
+          push: true


### PR DESCRIPTION
We need to upload the private key and private key passwords first as repository secrets.
The public key later needs to go into the Acorn Official Manager Account