### PR TITLE
Set job memory limits

### DIFF
--- a/amp/Acornfile
+++ b/amp/Acornfile
@@ -53,8 +53,6 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
-		GOGC:                "25"
-		NODE_OPTIONS:        "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT: "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:  "@{secrets.aws-context.aws-region}"
 		VPC_ID:              "@{secrets.aws-context.vpc-id}"

--- a/amp/Acornfile
+++ b/amp/Acornfile
@@ -42,7 +42,7 @@ services: "remote-write": {
 }
 
 jobs: apply: {
-	memory: 768Mi
+	memory: 512Mi
 	build: {
 		context: "."
 		additionalContexts: {
@@ -53,6 +53,8 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
+		GOGC:                "25"
+		NODE_OPTIONS:        "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT: "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:  "@{secrets.aws-context.aws-region}"
 		VPC_ID:              "@{secrets.aws-context.vpc-id}"

--- a/amp/Acornfile
+++ b/amp/Acornfile
@@ -42,6 +42,7 @@ services: "remote-write": {
 }
 
 jobs: apply: {
+	memory: 768Mi
 	build: {
 		context: "."
 		additionalContexts: {

--- a/amp/Dockerfile
+++ b/amp/Dockerfile
@@ -19,4 +19,8 @@ COPY ./scripts ./scripts
 COPY --from=utils ./scripts/ ./scripts/
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/amp/amp .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/dynamodb/Acornfile
+++ b/dynamodb/Acornfile
@@ -106,8 +106,6 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
-		GOGC:                         "25"
-		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/dynamodb/Acornfile
+++ b/dynamodb/Acornfile
@@ -98,6 +98,7 @@ services: {
 }
 
 jobs: apply: {
+	memory: 768Mi
 	build: {
 		context:    "."
 		dockerfile: "Dockerfile"

--- a/dynamodb/Acornfile
+++ b/dynamodb/Acornfile
@@ -98,7 +98,7 @@ services: {
 }
 
 jobs: apply: {
-	memory: 768Mi
+	memory: 512Mi
 	build: {
 		context:    "."
 		dockerfile: "Dockerfile"
@@ -106,6 +106,8 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
+		GOGC:                         "25"
+		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/dynamodb/Dockerfile
+++ b/dynamodb/Dockerfile
@@ -22,4 +22,8 @@ COPY cdk.json ./
 COPY scripts ./scripts
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/dynamo/dynamo .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/elasticache/memcached.Dockerfile
+++ b/elasticache/memcached.Dockerfile
@@ -21,4 +21,8 @@ COPY cdk.json ./
 COPY scripts ./scripts
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/memcached/elasticache .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/elasticache/memcached/Acornfile
+++ b/elasticache/memcached/Acornfile
@@ -31,7 +31,7 @@ services: admin: {
 }
 
 jobs: apply: {
-	memory: 768Mi
+	memory: 512Mi
 	build: {
 		context:    "../"
 		dockerfile: "../memcached.Dockerfile"
@@ -39,6 +39,8 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
+		GOGC:                         "25"
+		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/elasticache/memcached/Acornfile
+++ b/elasticache/memcached/Acornfile
@@ -31,6 +31,7 @@ services: admin: {
 }
 
 jobs: apply: {
+	memory: 768Mi
 	build: {
 		context:    "../"
 		dockerfile: "../memcached.Dockerfile"

--- a/elasticache/memcached/Acornfile
+++ b/elasticache/memcached/Acornfile
@@ -39,8 +39,6 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
-		GOGC:                         "25"
-		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/elasticache/redis.Dockerfile
+++ b/elasticache/redis.Dockerfile
@@ -21,4 +21,8 @@ COPY cdk.json ./
 COPY scripts ./scripts
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/redis/elasticache .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/elasticache/redis/Acornfile
+++ b/elasticache/redis/Acornfile
@@ -31,7 +31,7 @@ services: admin: {
 }
 
 jobs: apply: {
-	memory: 768Mi
+	memory: 512Mi
 	build: {
 		context:    "../"
 		dockerfile: "../redis.Dockerfile"
@@ -39,6 +39,8 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
+		GOGC:                         "25"
+		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/elasticache/redis/Acornfile
+++ b/elasticache/redis/Acornfile
@@ -39,8 +39,6 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
-		GOGC:                         "25"
-		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/elasticache/redis/Acornfile
+++ b/elasticache/redis/Acornfile
@@ -31,6 +31,7 @@ services: admin: {
 }
 
 jobs: apply: {
+	memory: 768Mi
 	build: {
 		context:    "../"
 		dockerfile: "../redis.Dockerfile"

--- a/iam/role/Acornfile
+++ b/iam/role/Acornfile
@@ -27,7 +27,7 @@ services: role: {
 }
 
 jobs: apply: {
-	memory: 768Mi
+	memory: 512Mi
 	build: {
 		context: "."
 		additionalContexts: {
@@ -37,6 +37,8 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
+		GOGC:                "25"
+		NODE_OPTIONS:        "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT: "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:  "@{secrets.aws-context.aws-region}"
 		VPC_ID:              "@{secrets.aws-context.vpc-id}"

--- a/iam/role/Acornfile
+++ b/iam/role/Acornfile
@@ -27,6 +27,7 @@ services: role: {
 }
 
 jobs: apply: {
+	memory: 768Mi
 	build: {
 		context: "."
 		additionalContexts: {

--- a/iam/role/Acornfile
+++ b/iam/role/Acornfile
@@ -37,8 +37,6 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
-		GOGC:                "25"
-		NODE_OPTIONS:        "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT: "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:  "@{secrets.aws-context.aws-region}"
 		VPC_ID:              "@{secrets.aws-context.vpc-id}"

--- a/iam/role/Dockerfile
+++ b/iam/role/Dockerfile
@@ -19,4 +19,8 @@ COPY ./scripts ./scripts
 COPY --from=utils ./scripts/ ./scripts/
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/iam/role/role .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/kms/key/Acornfile
+++ b/kms/key/Acornfile
@@ -61,13 +61,15 @@ services: key: {
 }
 
 jobs: apply: {
-	memory: 768Mi
+	memory: 512Mi
 	build: {
 		context: "."
 		additionalContexts: common: "../../libs"
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
+		GOGC:                "25"
+		NODE_OPTIONS:        "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT: "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:  "@{secrets.aws-context.aws-region}"
 		VPC_ID:              "@{secrets.aws-context.vpc-id}"

--- a/kms/key/Acornfile
+++ b/kms/key/Acornfile
@@ -68,8 +68,6 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
-		GOGC:                "25"
-		NODE_OPTIONS:        "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT: "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:  "@{secrets.aws-context.aws-region}"
 		VPC_ID:              "@{secrets.aws-context.vpc-id}"

--- a/kms/key/Acornfile
+++ b/kms/key/Acornfile
@@ -61,6 +61,7 @@ services: key: {
 }
 
 jobs: apply: {
+	memory: 768Mi
 	build: {
 		context: "."
 		additionalContexts: common: "../../libs"

--- a/kms/key/Dockerfile
+++ b/kms/key/Dockerfile
@@ -18,4 +18,8 @@ COPY ./cdk.json ./
 COPY ./scripts ./scripts
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/kms/key/key .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/rds/aurora/mysql/cluster/Acornfile
+++ b/rds/aurora/mysql/cluster/Acornfile
@@ -49,8 +49,10 @@ jobs: apply: {
 		}
 	}
 	files: "/app/config.json": std.toJSON(args)
-	memory: 768Mi
+	memory: 512Mi
 	env: {
+		GOGC:                         "25"
+		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/rds/aurora/mysql/cluster/Acornfile
+++ b/rds/aurora/mysql/cluster/Acornfile
@@ -51,8 +51,6 @@ jobs: apply: {
 	files: "/app/config.json": std.toJSON(args)
 	memory: 512Mi
 	env: {
-		GOGC:                         "25"
-		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/rds/aurora/mysql/cluster/Acornfile
+++ b/rds/aurora/mysql/cluster/Acornfile
@@ -49,7 +49,7 @@ jobs: apply: {
 		}
 	}
 	files: "/app/config.json": std.toJSON(args)
-	memory: 1024Mi
+	memory: 768Mi
 	env: {
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"

--- a/rds/aurora/mysql/serverless-v1/Acornfile
+++ b/rds/aurora/mysql/serverless-v1/Acornfile
@@ -36,6 +36,7 @@ services: rds: {
 
 jobs: apply: {
 	name: "CloudFormation Provisioner"
+	memory: 768Mi
 	build: {
 		context:    "../../../"
 		dockerfile: "../../../mysql.Dockerfile"

--- a/rds/aurora/mysql/serverless-v1/Acornfile
+++ b/rds/aurora/mysql/serverless-v1/Acornfile
@@ -35,8 +35,8 @@ services: rds: {
 }
 
 jobs: apply: {
-	name: "CloudFormation Provisioner"
-	memory: 768Mi
+	name:   "CloudFormation Provisioner"
+	memory: 512Mi
 	build: {
 		context:    "../../../"
 		dockerfile: "../../../mysql.Dockerfile"
@@ -48,6 +48,8 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
+		GOGC:                         "25"
+		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/rds/aurora/mysql/serverless-v1/Acornfile
+++ b/rds/aurora/mysql/serverless-v1/Acornfile
@@ -48,8 +48,6 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
-		GOGC:                         "25"
-		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/rds/aurora/mysql/serverless-v2/Acornfile
+++ b/rds/aurora/mysql/serverless-v2/Acornfile
@@ -34,6 +34,7 @@ services: rds: {
 }
 
 jobs: apply: {
+	memory: 768Mi
 	build: {
 		context:    "../../../"
 		dockerfile: "../../../mysql.Dockerfile"

--- a/rds/aurora/mysql/serverless-v2/Acornfile
+++ b/rds/aurora/mysql/serverless-v2/Acornfile
@@ -34,7 +34,7 @@ services: rds: {
 }
 
 jobs: apply: {
-	memory: 768Mi
+	memory: 512Mi
 	build: {
 		context:    "../../../"
 		dockerfile: "../../../mysql.Dockerfile"
@@ -46,6 +46,8 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
+		GOGC:                         "25"
+		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/rds/aurora/mysql/serverless-v2/Acornfile
+++ b/rds/aurora/mysql/serverless-v2/Acornfile
@@ -46,8 +46,6 @@ jobs: apply: {
 	}
 	files: "/app/config.json": std.toJSON(args)
 	env: {
-		GOGC:                         "25"
-		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/rds/aurora/postgres/cluster/Acornfile
+++ b/rds/aurora/postgres/cluster/Acornfile
@@ -49,8 +49,10 @@ jobs: apply: {
 		}
 	}
 	files: "/app/config.json": std.toJSON(args)
-	memory: 768Mi
+	memory: 512Mi
 	env: {
+		GOGC:                         "25"
+		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/rds/aurora/postgres/cluster/Acornfile
+++ b/rds/aurora/postgres/cluster/Acornfile
@@ -51,8 +51,6 @@ jobs: apply: {
 	files: "/app/config.json": std.toJSON(args)
 	memory: 512Mi
 	env: {
-		GOGC:                         "25"
-		NODE_OPTIONS:                 "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 		VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/rds/aurora/postgres/cluster/Acornfile
+++ b/rds/aurora/postgres/cluster/Acornfile
@@ -49,7 +49,7 @@ jobs: apply: {
 		}
 	}
 	files: "/app/config.json": std.toJSON(args)
-	memory: 1024Mi
+	memory: 768Mi
 	env: {
 		CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"

--- a/rds/mysql.Dockerfile
+++ b/rds/mysql.Dockerfile
@@ -25,4 +25,8 @@ COPY ./cdk.json ./
 COPY ./scripts ./scripts
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/rds/rds .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/rds/postgres.Dockerfile
+++ b/rds/postgres.Dockerfile
@@ -26,4 +26,8 @@ COPY ./cdk.json ./
 COPY ./scripts ./scripts
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/rds/rds .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/s3/Acornfile
+++ b/s3/Acornfile
@@ -58,6 +58,7 @@ services: admin: {
 
 jobs: {
 	cleanup: {
+		memory: 768Mi
 		build: {
 			context:    "../utils/s3-cleanup/"
 			dockerfile: "../utils/s3-cleanup/Dockerfile"
@@ -82,6 +83,7 @@ jobs: {
 
 	apply: {
 		dependsOn: ["cleanup"]
+		memory: 128Mi
 		build: {
 			context:    "."
 			dockerfile: "Dockerfile"

--- a/s3/Acornfile
+++ b/s3/Acornfile
@@ -83,7 +83,7 @@ jobs: {
 
 	apply: {
 		dependsOn: ["cleanup"]
-		memory: 128Mi
+		memory: 768Mi 
 		build: {
 			context:    "."
 			dockerfile: "Dockerfile"

--- a/s3/Acornfile
+++ b/s3/Acornfile
@@ -58,7 +58,8 @@ services: admin: {
 
 jobs: {
 	cleanup: {
-		memory: 768Mi
+		// might be possible to reduce this memory limit even further
+		memory: 256Mi
 		build: {
 			context:    "../utils/s3-cleanup/"
 			dockerfile: "../utils/s3-cleanup/Dockerfile"
@@ -83,7 +84,7 @@ jobs: {
 
 	apply: {
 		dependsOn: ["cleanup"]
-		memory: 768Mi 
+		memory: 512Mi
 		build: {
 			context:    "."
 			dockerfile: "Dockerfile"
@@ -94,6 +95,8 @@ jobs: {
 		}
 		files: "/app/config.json": std.toJSON(args)
 		env: {
+			GOGC:                         "25"
+			NODE_OPTIONS:                 "--max-old-space-size=256"
 			CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 			CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 			VPC_ID:                       "@{secrets.aws-context.vpc-id}"
@@ -117,6 +120,7 @@ jobs: {
 				"cloudformation:UpdateStack",
 				"cloudformation:GetTemplateSummary",
 				"cloudformation:DeleteStack",
+				"cloudformation:GetTemplate",
 				"s3:CreateBucket",
 				"s3:DeleteBucket",
 				"s3:PutBucketVersioning",

--- a/s3/Acornfile
+++ b/s3/Acornfile
@@ -95,8 +95,6 @@ jobs: {
 		}
 		files: "/app/config.json": std.toJSON(args)
 		env: {
-			GOGC:                         "25"
-			NODE_OPTIONS:                 "--max-old-space-size=256"
 			CDK_DEFAULT_ACCOUNT:          "@{secrets.aws-context.account-id}"
 			CDK_DEFAULT_REGION:           "@{secrets.aws-context.aws-region}"
 			VPC_ID:                       "@{secrets.aws-context.vpc-id}"

--- a/s3/Dockerfile
+++ b/s3/Dockerfile
@@ -8,7 +8,7 @@ RUN --mount=type=cache,target=/root/go/pkg \
     ls ../ &&\
     go build -o s3 .
 
-FROM ghcr.io/acorn-io/aws/utils/cdk-runner:v0.6.0 as cdk-runner
+FROM ghcr.io/acorn-io/aws/utils/cdk-runner:v0.7.1 as cdk-runner
 FROM cgr.dev/chainguard/wolfi-base
 RUN apk add -U --no-cache nodejs bash busybox jq curl zip && \
     apk del --no-cache wolfi-base apk-tools

--- a/s3/Dockerfile
+++ b/s3/Dockerfile
@@ -19,4 +19,8 @@ COPY ./scripts ./scripts
 COPY --from=utils ./scripts/ ./scripts/
 COPY --from=cdk-runner /cdk-runner .
 COPY --from=build /src/s3/s3 .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]

--- a/secrets-manager/Acornfile
+++ b/secrets-manager/Acornfile
@@ -12,7 +12,7 @@ args: {
 services: "secret-manager": generated: job: "generate-secrets"
 
 jobs: "generate-secrets": {
-	memory: 768Mi
+	memory: 128Mi
 	build: context: "."
 	schedule: args.refreshSchedule
 	env: {

--- a/secrets-manager/Acornfile
+++ b/secrets-manager/Acornfile
@@ -12,6 +12,7 @@ args: {
 services: "secret-manager": generated: job: "generate-secrets"
 
 jobs: "generate-secrets": {
+	memory: 768Mi
 	build: context: "."
 	schedule: args.refreshSchedule
 	env: {

--- a/sqs/Acornfile
+++ b/sqs/Acornfile
@@ -73,8 +73,6 @@ jobs: apply: {
 	files: "/app/config.json": std.toJSON(args)
 	events: ["create", "update", "delete"]
 	env: {
-		GOGC:                "25"
-		NODE_OPTIONS:        "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT: "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:  "@{secrets.aws-context.aws-region}"
 		VPC_ID:              "@{secrets.aws-context.vpc-id}"

--- a/sqs/Acornfile
+++ b/sqs/Acornfile
@@ -62,6 +62,7 @@ services: {
 }
 
 jobs: apply: {
+	memory: 768Mi
 	build: {
 		context: "."
 		additionalContexts: {

--- a/sqs/Acornfile
+++ b/sqs/Acornfile
@@ -62,7 +62,7 @@ services: {
 }
 
 jobs: apply: {
-	memory: 768Mi
+	memory: 512Mi
 	build: {
 		context: "."
 		additionalContexts: {
@@ -73,6 +73,8 @@ jobs: apply: {
 	files: "/app/config.json": std.toJSON(args)
 	events: ["create", "update", "delete"]
 	env: {
+		GOGC:                "25"
+		NODE_OPTIONS:        "--max-old-space-size=256"
 		CDK_DEFAULT_ACCOUNT: "@{secrets.aws-context.account-id}"
 		CDK_DEFAULT_REGION:  "@{secrets.aws-context.aws-region}"
 		VPC_ID:              "@{secrets.aws-context.vpc-id}"

--- a/sqs/Dockerfile
+++ b/sqs/Dockerfile
@@ -22,4 +22,8 @@ COPY ./scripts ./scripts
 COPY --from=build /src/sqs/sqs .
 COPY --from=utils . ./scripts/ ./scripts/
 COPY --from=cdk-runner /cdk-runner .
+
+ENV GOGC="25"
+ENV NODE_OPTIONS="--max-old-space-size=256"
+
 CMD [ "/app/cdk-runner" ]


### PR DESCRIPTION
After some investigation it turns out that most of the memory consumption comes from JSII and its use of NodeJS at runtime. JSII seems to load all of [aws-cdk-lib](https://www.npmjs.com/package/aws-cdk-lib) into memory which eats up a ton of memory immediately. Tweaking Node's `max-old-space-size` and Go's `GOGC` allows our apply job to run within 512Mi of memory. Which wasn't possible before. I think this should be consistent across all of our service acorns but more testing is required. 