### PR TITLE
RDS: add initial arg/prop validation & password plugin for mysql client

### DIFF
--- a/rds/aurora/mysql/cluster/rds.go
+++ b/rds/aurora/mysql/cluster/rds.go
@@ -113,6 +113,12 @@ func main() {
 	}
 
 	common.AppendScopedTags(app, stackProps.Tags)
+
+	err := rds.ValidateProps(stackProps)
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
 	NewRDSStack(app, stackProps)
 
 	app.Synth(nil)

--- a/rds/aurora/mysql/serverless-v1/rds.go
+++ b/rds/aurora/mysql/serverless-v1/rds.go
@@ -127,6 +127,10 @@ func main() {
 	if err := common.NewConfig(stackProps); err != nil {
 		logrus.Fatal(err)
 	}
+	err := rds.ValidateProps(stackProps)
+	if err != nil {
+		logrus.Fatal(err)
+	}
 
 	NewRDSStack(app, stackProps)
 

--- a/rds/aurora/mysql/serverless-v2/rds.go
+++ b/rds/aurora/mysql/serverless-v2/rds.go
@@ -104,6 +104,11 @@ func main() {
 	}
 
 	common.AppendScopedTags(app, stackProps.Tags)
+
+	err := rds.ValidateProps(stackProps)
+	if err != nil {
+		logrus.Fatal(err)
+	}
 	NewRDSStack(app, stackProps)
 
 	app.Synth(nil)

--- a/rds/common.go
+++ b/rds/common.go
@@ -1,6 +1,8 @@
 package rds
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-cdk-go/awscdk/v2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsec2"
 	"github.com/aws/aws-cdk-go/awscdk/v2/awsrds"
@@ -28,6 +30,7 @@ var (
 
 type RDSStackProps struct {
 	awscdk.StackProps
+	RegularUser               string            `json:"username"`
 	AdminUser                 string            `json:"adminUsername"`
 	DatabaseName              string            `json:"dbName"`
 	DeletionProtection        bool              `json:"deletionProtection"`
@@ -46,6 +49,16 @@ type RDSStackProps struct {
 	// Scaling Units for serverless v2
 	AuroraCapacityUnitsV2Min float64 `json:"auroraCapacityUnitsV2Min"`
 	AuroraCapacityUnitsV2Max float64 `json:"auroraCapacityUnitsV2Max"`
+}
+
+// ValidateProps validates the given props
+// returns an error if the props are invalid
+func ValidateProps(props *RDSStackProps) error {
+	if props.AdminUser == props.RegularUser {
+		return fmt.Errorf("the admin username (%s) must differ from the standard username (%s)", props.AdminUser, props.RegularUser)
+	}
+
+	return nil
 }
 
 type SnapshotAspect struct {


### PR DESCRIPTION
The shared object file `/usr/lib/mariadb-10.11/plugin/caching_sha2_password.so` is used by the mysql client when connecting to modern MariaDB clusters (sometimes...)

It seems to left out of the MariaDB container because it's more intended for server use. Copying it in from another container that gets it from `apk add mariadb-connector-c` seems to work fine. It seems like disabling the password hashing system is a possibility but it's generally viewed as a security downgrade.

I added a props/args validation function that we can use to prevent erroneous inputs. For now I've only added a check that asserts the admin username is not the same as the new user's username. I noticed that if they're the same the `create-user` job will fail repeatedly. Presumably because it's trying to modify the admin user and that's not possible.

I had wanted to address https://github.com/acorn-io/manager/issues/1538 but it appears that we actually can't specify a new admin username when restoring from a snapshot. There is an original admin username associated with the snapshot that appears to take priority over the new one. The restoration finishes and the new admin does not exist so our `create-user` job fails with `ERROR 1045 (28000): Access denied for user 'newadmin'`. The AWS UI does not allow specifying/modifying the admin username when restoring from a snapshot either. So this will need to be documented. A new regular user can still be created.