### PR TITLE
enhance: add arg to set custom stack name for IAM Role

### DIFF
--- a/iam/role/Acornfile
+++ b/iam/role/Acornfile
@@ -3,6 +3,8 @@ description: "AWS Identity and Access Management (IAM) Role"
 info:        localData.info
 
 args: {
+	// Name for the CloudFormation stack. The default is auto-generated.
+	stackName: ""
 	// Name of the Role to create. The default is auto-generated.
 	roleName: ""
 	// The ARN of the principal that will be allowed to assume the role. Required.
@@ -43,7 +45,9 @@ jobs: apply: {
 		ACORN_ACCOUNT:       "@{acorn.account}"
 		ACORN_NAME:          "@{acorn.name}"
 		ACORN_PROJECT:       "@{acorn.project}"
-		ACORN_EXTERNAL_ID:   "@{acorn.externalID}"
+
+		// cdk-runner requires the stack name to be present as the environment variable ACORN_EXTERNAL_ID
+		ACORN_EXTERNAL_ID: std.ifelse(args.stackName == "", "@{acorn.externalId}", "@{args.stackName}")
 	}
 	events: ["create", "update", "delete"]
 	permissions: rules: [{

--- a/iam/role/README.md
+++ b/iam/role/README.md
@@ -13,11 +13,11 @@ The ARN can refer to an AWS account, an IAM user, an IAM role, or specific assum
 
 ```
 acorn run ghcr.io/acorn-io/aws/iam/role:v0.1.0 \
-  --role-name="my-role" \
+  --roleName="my-role" \
   --policy @policy.json \
-  --trusted-arn="<arn>" \
-  --external-ids="external-id-one,external-id-two" \
-  --max-session-duration-minutes=120
+  --trustedArn="<arn>" \
+  --externalIds="external-id-one,external-id-two" \
+  --maxSessionDurationMinutes=120
 ```
 
 ### Using the service in an Acornfile
@@ -63,16 +63,17 @@ containers: mycontainer: {
 
 ### Arguments
 
-| Name                             | Description                                                                            | Required | Default                  |
-|----------------------------------|----------------------------------------------------------------------------------------|----------|--------------------------|
-| `--role-name`                    | The name of the IAM role to create.                                                    | No       | (generated)              |
-| `--policy`                       | The IAM policy to attach to the role as an inline policy. This must be in JSON format. | Yes      |                          |
-| `--trusted-arn`                  | The ARN of the entity that can assume the role.                                        | Yes      |                          |
-| `--external-ids`                 | A comma-separated list of external IDs to use in the trust relationship.               | No       | (none)                   |
-| `--max-session-duration-minutes` | The maximum session duration in minutes for the role.                                  | No       | 60                       |
-| `--path`                         | The path in which to create the Role.                                                  | No       | "/"                      |
-| `--tags`                         | Tags to attach to the Role.                                                            | No       | (none)                   |
-| `--description`                  | Description to attach to the Role.                                                     | No       | "Acorn created IAM Role" |
+| Name                          | Description                                                                            | Required | Default                  |
+|-------------------------------|----------------------------------------------------------------------------------------|----------|--------------------------|
+| `--stackName`                 | The name of the CloudFormation stack to create.                                        | No       | (generated)              |
+| `--roleName`                  | The name of the IAM role to create.                                                    | No       | (generated)              |
+| `--policy`                    | The IAM policy to attach to the role as an inline policy. This must be in JSON format. | Yes      |                          |
+| `--trustedArn`                | The ARN of the entity that can assume the role.                                        | Yes      |                          |
+| `--externalIds`               | A comma-separated list of external IDs to use in the trust relationship.               | No       | (none)                   |
+| `--maxSessionDurationMinutes` | The maximum session duration in minutes for the role.                                  | No       | 60                       |
+| `--path`                      | The path in which to create the Role.                                                  | No       | "/"                      |
+| `--tags`                      | Tags to attach to the Role.                                                            | No       | (none)                   |
+| `--description`               | Description to attach to the Role.                                                     | No       | "Acorn created IAM Role" |
 
 ### Outputs
 


### PR DESCRIPTION
This is needed for some work that Donnie is doing.

I would have liked to be able to leave `ACORN_EXTERNAL_ID` as it is and just process the stack name the way we process the rest of the args, but cdk-runner is written in a way that requires the stack name to be present in that environment variable, so that is why I implemented it this way.